### PR TITLE
Allow the client to be set manually

### DIFF
--- a/request.go
+++ b/request.go
@@ -28,6 +28,11 @@ func (r *Request) Client() *Client {
 	return r.client
 }
 
+// SetClient sets the client
+func (r *Request) SetClient(client *Client) {
+	r.client = client
+}
+
 // ParseRequest parses a new request from a buffered connection
 func ParseRequest(rd *bufio.Reader) (req *Request, err error) {
 	var line []byte


### PR DESCRIPTION
I'm implementing Redis transactions (https://github.com/tsileo/silokv/blob/master/main.go), so I keep a buffer of request I manually apply on `EXEC`, but I need a way to set the client (the context) manually.
