### PR TITLE
Added Client.Close() method

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	ID         uint64      `json:"id,omitempty"`
 	RemoteAddr string      `json:"remote_addr,omitempty"`
 	Ctx        interface{} `json:"ctx,omitempty"`
+	doClose    bool
 
 	lastAccess time.Time
 	lastCmd    string
@@ -36,6 +37,14 @@ func NewClient(addr string) *Client {
 		lastAccess: now,
 		baseInfo:   baseInfo{StartTime: now},
 	}
+}
+
+// Close will disconnect the client when the buffer has been send
+func (i *Client) Close() {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	i.doClose = true
 }
 
 // OnCommand callback to track user command

--- a/server.go
+++ b/server.go
@@ -147,6 +147,10 @@ func (srv *Server) ServeClient(conn net.Conn) {
 		if _, err = res.WriteTo(conn); err != nil {
 			return
 		}
+
+		if client.doClose {
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
In order to implement a 'QUIT' method the client now has a Close() method. It's more of a graceful close, where the socket is only closed once the buffer has been send.
