### PR TITLE
Return of TotalConnections and TotalCommands

### DIFF
--- a/info.go
+++ b/info.go
@@ -126,3 +126,15 @@ func (i *ServerInfo) ClientsString() string {
 	}
 	return str
 }
+
+// TotalConnections returns the total number of connections made since the
+// start of the server.
+func (i *ServerInfo) TotalConnections() int64 {
+	return i.connections.Value()
+}
+
+// TotalCommands returns the total number of commands executed since the start
+// of the server.
+func (i *ServerInfo) TotalCommands() int64 {
+	return i.commands.Value()
+}


### PR DESCRIPTION
The number of processed commands and the count of connections made are not available as plain integer values anymore, only as strings in a more general info string. This PR re-introduces them.

I used them in https://github.com/alicebob/miniredis/blob/master/miniredis.go#L186 and https://github.com/alicebob/miniredis/blob/master/miniredis.go#L202
