### PR TITLE
Fix slice out of bound exception in rare cases.

### DIFF
--- a/resp/bufio.go
+++ b/resp/bufio.go
@@ -221,6 +221,11 @@ func (b *bufioR) PeekLine(offset int) (bufioLn, error) {
 	if index < 0 {
 		return nil, errInlineRequestTooLong
 	}
+	// Although rarely, make sure '\n' is buffered.
+	if (start + index + 1) >= b.w {
+		b.require(offset + index + 2)
+		start = b.r + offset
+	}
 	return bufioLn(b.buf[start : start+index+2]), nil
 }
 


### PR DESCRIPTION
In rare cases, '\n' may not be buffered while '\r' is. This will cause consecutive "slice out of bound" failures of compact() calls due to b.r > b.w by 1.